### PR TITLE
add Starlight Blog support

### DIFF
--- a/docs/src/content/docs/configuration.mdx
+++ b/docs/src/content/docs/configuration.mdx
@@ -45,7 +45,7 @@ The Starlight Cooler Credit plugin accepts the following configuration options:
 
 **Default:** `"Starlight"`
 
-The `credit` option allows you to configure the credit text displayed in the table of contents of the Starlight website. There are [two preconfigured options](#preconfigured-options): `"Astro"` and `"Starlight"`. You can also provide a custom object to configure the credit text for each locale.
+The `credit` option allows you to configure the credit text displayed in the table of contents of the Starlight website. There are [three preconfigured options](#preconfigured-options): `"Astro"`, "Starlight", and `"Starlight Blog"`. You can also provide a custom object to configure the credit text for each locale.
 
 :::note
 Please note that if you want to provide credit text for each locale, that there has to be at least the locale value of your [`defaultLocale`](https://starlight.astro.build/reference/configuration/#defaultlocale) configured.
@@ -71,7 +71,7 @@ starlightCoolerCredit({
 
 #### Preconfigured options
 
-The `Astro` and `Starlight` options are preconfigured and can be used without any additional configuration.
+The `Astro`, `Starlight`, and `Starlight Blog` options are preconfigured and can be used without any additional configuration.
 
 import LanguagesList from "../../components/LanguagesList.astro";
 import TranslationsList from "../../components/TranslationsList.astro";

--- a/packages/starlight-cooler-credit/libs/config.ts
+++ b/packages/starlight-cooler-credit/libs/config.ts
@@ -5,7 +5,7 @@ const configSchema = z
     .object({
         credit: z
             .union([
-                z.enum(["Astro", "Starlight"]),
+                z.enum(["Astro", "Starlight", "Starlight Blog"]),
                 z.object({
                     title: z.union([z.string(), z.record(z.string())]),
                     href: z.string().url(),

--- a/packages/starlight-cooler-credit/libs/util.ts
+++ b/packages/starlight-cooler-credit/libs/util.ts
@@ -12,6 +12,8 @@ export default function getCreditText(
         if (type == "href") {
             if (config.credit === "Astro") {
                 return "https://docs.astro.build/";
+            } else if (config.credit === "Starlight Blog") {
+                return "https://github.com/HiDeoo/starlight-blog";
             } else if (config.credit === "Starlight") {
                 return "https://starlight.astro.build/";
             }

--- a/packages/starlight-cooler-credit/translations.ts
+++ b/packages/starlight-cooler-credit/translations.ts
@@ -3,6 +3,8 @@ export const Translations = {
         "starlightCoolerCredit.starlight.description": "Do you want to build your own docs? →",
         "starlightCoolerCredit.astro.title": "Built with Astro",
         "starlightCoolerCredit.astro.description": "Want to build your own static website? →",
+        "starlightCoolerCredit.starlight-blog.title": "Built with Starlight Blog",
+        "starlightCoolerCredit.starlight-blog.description": "Want to build your own Starlight Blog? →",
     },
     de: {
         "starlightCoolerCredit.starlight.description": "Möchtest du deine eigene Dokumentation erstellen? →",


### PR DESCRIPTION
This adds at least some of the initial infrastructure to also support [Starlight Blog](https://github.com/HiDeoo/starlight-blog) as a preconfigured option.

I did what I could figure out how to do!