### PR TITLE
Make Image optional in Cooler Credit Component by adding `showImage`` property

### DIFF
--- a/.changeset/rare-berries-pretend.md
+++ b/.changeset/rare-berries-pretend.md
@@ -1,0 +1,5 @@
+---
+"starlight-cooler-credit-docs": patch
+---
+
+Update documenation regarding `showImage` property

--- a/.changeset/smooth-onions-greet.md
+++ b/.changeset/smooth-onions-greet.md
@@ -1,0 +1,5 @@
+---
+"starlight-cooler-credit": patch
+---
+
+Make Image in Cooler Credit Component optional

--- a/docs/src/content/docs/configuration.mdx
+++ b/docs/src/content/docs/configuration.mdx
@@ -84,3 +84,10 @@ To provide translations for additional languages you support — or override the
 These are the English defaults of the existing strings Starlight Cooler Credit ships with:
 
 <TranslationsList />
+
+### `showImage`
+
+**Type:** `boolean`  
+**Default:** `true`
+
+The `showImage` option allows you to configure whether the image in the Cooler Credit component should be displayed or not. If set to `false`, the image will not be displayed.

--- a/docs/src/content/docs/de/configuration.mdx
+++ b/docs/src/content/docs/de/configuration.mdx
@@ -84,3 +84,10 @@ Um Übersetzungen für zusätzliche Sprachen, die du unterstützt, bereitzustell
 Dies sind die englischen Standardeinstellungen der vorhandenen Zeichenketten, mit denen Starlight Coolere Anerkennung ausgeliefert wird:
 
 <TranslationsList />
+
+### `showImage`
+
+**Type:** `boolean`  
+**Default:** `true`
+
+Mit der Option `showImage` kannst du festlegen, ob das Bild in der Komponente Cooler Credit angezeigt werden soll oder nicht. Wenn du `false` einstellst, wird das Bild nicht angezeigt.

--- a/docs/src/content/docs/de/configuration.mdx
+++ b/docs/src/content/docs/de/configuration.mdx
@@ -87,7 +87,7 @@ Dies sind die englischen Standardeinstellungen der vorhandenen Zeichenketten, mi
 
 ### `showImage`
 
-**Type:** `boolean`  
-**Default:** `true`
+**Typ:** `boolean`  
+**Standard:** `true`
 
 Mit der Option `showImage` kannst du festlegen, ob das Bild in der Komponente Cooler Credit angezeigt werden soll oder nicht. Wenn du `false` einstellst, wird das Bild nicht angezeigt.

--- a/packages/starlight-cooler-credit/components/Banner.astro
+++ b/packages/starlight-cooler-credit/components/Banner.astro
@@ -13,16 +13,18 @@ const locale = Astro.currentLocale
 	<a href={getCreditText(config, "href", translate, locale)}>
 		<h2>{getCreditText(config, "title", translate, locale)}</h2>
 		<div>
-				<div>
-					{getCreditText(config, "description", translate, locale) && 
-					<p>
-						{getCreditText(config, "description", translate, locale)} 
-					</p>
-			}
-				</div>
-			<div>
-				<Image src={HoustonOmg} alt="" width="180" />
-			</div>
+      <div>
+        {getCreditText(config, "description", translate, locale) && 
+          <p>
+            {getCreditText(config, "description", translate, locale)} 
+          </p>
+        }
+      </div>
+      {config.showImage && 
+        <div>
+          <Image src={HoustonOmg} alt="" width="180" />
+        </div>
+      }
 		</div>
 	</a>
 </aside>

--- a/packages/starlight-cooler-credit/libs/config.ts
+++ b/packages/starlight-cooler-credit/libs/config.ts
@@ -13,6 +13,7 @@ const configSchema = z
         }),
       ])
       .default("Starlight"),
+    showImage: z.boolean().optional().default(true),
   })
   .default({});
 


### PR DESCRIPTION
- Closes #39